### PR TITLE
Make consul service configurable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,18 +25,20 @@ You can change the settings for the plugin in the ``rabbitmq.config`` file under
 a ``rabbitmq_autocluster_consul`` stanza. The configuration can change any of these
 default values:
 
-+--------------+--------------------------------------+-----------+---------------+
-| Setting      | Description                          | Data Type | Default Value |
-+==============+======================================+===========+===============+
-| consul_host  | The Consul client host to use        | list      | ``localhost`` |
-+--------------+--------------------------------------+-----------+---------------+
-| consul_port  | The port to connect on               | integer   | ``8500``      |
-+--------------+--------------------------------------+-----------+---------------+
-| consul_acl   | The Consul ACL to use for requests   | list      | Unset         |
-+--------------+--------------------------------------+-----------+---------------+
-| cluster_name | The name of the RabbitMQ cluster to  | list      | Unset         |
-|              | restrict membership to               |           |               |
-+--------------+--------------------------------------+-----------+---------------+
++----------------+--------------------------------------+-----------+---------------+
+| Setting        | Description                          | Data Type | Default Value |
++================+======================================+===========+===============+
+| consul_host    | The Consul client host to use        | list      | ``localhost`` |
++----------------+--------------------------------------+-----------+---------------+
+| consul_port    | The port to connect on               | integer   | ``8500``      |
++----------------+--------------------------------------+-----------+---------------+
+| consul_acl     | The Consul ACL to use for requests   | list      | Unset         |
++----------------+--------------------------------------+-----------+---------------+
+| consul_service | The Consul service name to register  | list      | ``rabbitmq``  |
++----------------+--------------------------------------+-----------+---------------+
+| cluster_name   | The name of the RabbitMQ cluster to  | list      | Unset         |
+|                | restrict membership to               |           |               |
++----------------+--------------------------------------+-----------+---------------+
 
 *Exaple rabbitmq.config*
 
@@ -47,6 +49,7 @@ default values:
         {consul_host, "localhost"},
         {consul_port, 8500},
         {consul_acl, "example-acl-token"},
+        {consul_service, "rabbitmq-test"},
         {cluster_name, "test"}
       ]}
     ].

--- a/src/autocluster_consul.erl
+++ b/src/autocluster_consul.erl
@@ -14,7 +14,7 @@
                     {cleanup,     {autocluster_consul, shutdown, []}},
                     {enables,     pre_boot}]}).
 
--define(DEFAULT_CONSUL_SERVICE,  "rabbitmq").
+-define(DEFAULT_CONSUL_SERVICE,  "rabbitmq-autocluster").
 
 %% @public
 %% @spec init() -> ok


### PR DESCRIPTION
This fixes #6 and allows configuring whatever Consul service name you'd like.

**WARNING:** All Erlang changes have been cargo-culted. I have no idea what I'm doing in Erlang.

I tried to build and test it, but I get this error in `rabbitmq-public-umbrella`:

```
$ make BRANCH=rabbitmq_v3_5_3 up_c
(cd . && git fetch -p && git checkout rabbitmq_v3_5_3 && (test "$(git branch | grep '^*')" = "* (detached from rabbitmq_v3_5_3)" || git pull --ff-only))
Note: checking out 'rabbitmq_v3_5_3'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>

HEAD is now at b575b1b... deploy-community-plugins.sh: Don't maintain permissions for now
You are not currently on a branch. Please specify which
branch you want to merge with. See git-pull(1) for details.

    git pull <remote> <branch>

make: *** [.+named_update] Error 1
```